### PR TITLE
Update to React 18 createRoot

### DIFF
--- a/src/index.jsx
+++ b/src/index.jsx
@@ -1,16 +1,15 @@
 // src/index.jsx
 import React from 'react';
-import ReactDOM from 'react-dom';
+import { createRoot } from 'react-dom/client';
 import './styles/index.css'; // Ensure this path is correct
 import App from './App';
 import reportWebVitals from './reportWebVitals';
 
 // Wrap the App component in React.StrictMode to highlight potential problems
-ReactDOM.render(
+createRoot(document.getElementById('root')).render(
   <React.StrictMode>
     <App />
-  </React.StrictMode>,
-  document.getElementById('root') // Mount the App component to the DOM element with the id 'root'
+  </React.StrictMode>
 );
 
 // Call reportWebVitals to measure performance of the app


### PR DESCRIPTION
## Summary
- switch to `createRoot` API from `react-dom/client`

## Testing
- `npm start`


------
https://chatgpt.com/codex/tasks/task_e_684c8ac36ae483278ab565f48695d6ac