### PR TITLE
Fix NavLink active styling

### DIFF
--- a/src/components/Navigation.jsx
+++ b/src/components/Navigation.jsx
@@ -7,22 +7,22 @@ function Navigation() {
     <nav>
       <ul>
         <li>
-          <NavLink exact to='/' activeClassName='active'>
+          <NavLink to='/' className={({ isActive }) => (isActive ? 'active' : undefined)}>
             About Me
           </NavLink>
         </li>
         <li>
-          <NavLink to='/portfolio' activeClassName='active'>
+          <NavLink to='/portfolio' className={({ isActive }) => (isActive ? 'active' : undefined)}>
             Portfolio
           </NavLink>
         </li>
         <li>
-          <NavLink to='/contact' activeClassName='active'>
+          <NavLink to='/contact' className={({ isActive }) => (isActive ? 'active' : undefined)}>
             Contact
           </NavLink>
         </li>
         <li>
-          <NavLink to='/resume' activeClassName='active'>
+          <NavLink to='/resume' className={({ isActive }) => (isActive ? 'active' : undefined)}>
             Resume
           </NavLink>
         </li>


### PR DESCRIPTION
## Summary
- remove deprecated NavLink props
- use function-based `className` for active state

## Testing
- `npm run lint` *(fails: Parsing error for JSX files)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684c8ac546c88327a51682fcb1112ed9