### PR TITLE
Add responsive styles to Contact page layout

### DIFF
--- a/src/styles/Contact.css
+++ b/src/styles/Contact.css
@@ -105,3 +105,148 @@
 .contact-form button {
   font-family: 'Lato', 'Helvetica Neue', sans-serif;
 }
+
+/* -----------------------------------------------------------------------
+   New responsive styles for the updated Contact page layout
+   --------------------------------------------------------------------- */
+
+.contact_us_green {
+  padding: 2rem 1rem;
+  background-color: #f8f9fa;
+}
+
+.responsive-container-block {
+  display: flex;
+  flex-wrap: wrap;
+  width: 100%;
+  justify-content: center;
+}
+
+.responsive-container-block.container {
+  max-width: 1200px;
+  margin: 0 auto;
+  gap: 2rem;
+  align-items: flex-start;
+}
+
+.responsive-cell-block {
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+}
+
+.wk-desk-7 {
+  flex-basis: 60%;
+}
+
+.wk-desk-5 {
+  flex-basis: 40%;
+}
+
+.wk-tab-12,
+.wk-mobile-12,
+.wk-ipadp-10 {
+  flex-basis: 100%;
+}
+
+.line {
+  border-right: 2px solid #e0e0e0;
+}
+
+.form-box,
+.container-box {
+  width: 100%;
+}
+
+.head-text-box,
+.text-content {
+  text-align: center;
+  margin-bottom: 1.5rem;
+}
+
+.text-blk {
+  margin: 0;
+}
+
+.contactus-head {
+  font-family: 'Montserrat', 'Arial', sans-serif;
+  font-weight: 600;
+  font-size: 1.8rem;
+  color: #2d5f8b;
+  margin-bottom: 0.5rem;
+}
+
+.contactus-subhead {
+  font-family: 'Lato', 'Helvetica Neue', sans-serif;
+  font-size: 1rem;
+  color: #2c2c2c;
+}
+
+.workik-contact-bigbox,
+.workik-contact-box {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.text-box {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.contact-svg,
+.social-svg {
+  width: 24px;
+  height: 24px;
+}
+
+.contact-text {
+  font-family: 'Lato', 'Helvetica Neue', sans-serif;
+  font-size: 1rem;
+  color: #2c2c2c;
+}
+
+.social-media-links {
+  margin-top: 1rem;
+  display: flex;
+  gap: 1rem;
+  justify-content: center;
+}
+
+/* Responsive adjustments */
+@media (max-width: 1024px) {
+  .wk-desk-7,
+  .wk-desk-5 {
+    flex-basis: 100%;
+  }
+
+  .line {
+    border-right: none;
+  }
+}
+
+@media (max-width: 768px) {
+  .responsive-container-block.container {
+    flex-direction: column;
+    gap: 2rem;
+  }
+}
+
+@media (max-width: 480px) {
+  .contactus-head {
+    font-size: 1.5rem;
+  }
+
+  .contactus-subhead,
+  .contact-text {
+    font-size: 0.9rem;
+  }
+
+  .contact-svg,
+  .social-svg {
+    width: 20px;
+    height: 20px;
+  }
+}


### PR DESCRIPTION
## Summary
- extend `Contact.css` with responsive rules for new contact classes
- keep form/details aligned using flexbox

## Testing
- `npm run lint` *(fails: Parsing error - The keyword 'import' is reserved)*
- `npm test -- --watchAll=false --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_684c8acdcfe88327b26bca56aba0290f