### PR TITLE
Add EmailJS env docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+REACT_APP_EMAILJS_SERVICE_ID=your_service_id
+REACT_APP_EMAILJS_TEMPLATE_ID=your_template_id
+REACT_APP_EMAILJS_USER_ID=your_user_id

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ This is a portfolio project built with React. It showcases the developer's proje
 7. [Issues](#7-issues)
 8. [License](#8-license)
 9. [Acknowledgements](#9-acknowledgements)
+10. [Environment Variables](#10-environment-variables)
 
 ## 1. Features
 
@@ -131,3 +132,15 @@ This project is licensed under the MIT License. See the LICENSE file for details
 - [Google Fonts](https://fonts.google.com/) for font resources
 
 Feel free to customize and expand upon this template to better suit your project and preferences.
+
+## 10. Environment Variables
+
+This project uses EmailJS to handle form submissions. Set the following variables in a `.env` file or in your deployment environment:
+
+```bash
+REACT_APP_EMAILJS_SERVICE_ID=your_service_id
+REACT_APP_EMAILJS_TEMPLATE_ID=your_template_id
+REACT_APP_EMAILJS_USER_ID=your_user_id
+```
+
+You can copy `.env.example` to `.env` and replace the placeholder values with your own EmailJS credentials.


### PR DESCRIPTION
## Summary
- document required EmailJS environment variables
- provide `.env.example` with placeholder keys

## Testing
- `npm test -- --watchAll=false --passWithNoTests`
- `npm run lint` *(fails: Parsing error: The keyword 'import' is reserved)*

------
https://chatgpt.com/codex/tasks/task_e_687e43d3b9b48327ba42c01e5bcea1cf